### PR TITLE
Combined dependency updates (2026-04-22)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Rules cache
         id: rules-cache
-        uses: actions/cache@v5.0.4
+        uses: actions/cache@v5.0.5
         with:
           path: .tdrules-cache
           key: cache-${{ matrix.scope }}-v1-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,12 +203,12 @@ jobs:
       # Some files (e.g. junit reports) have 600 permissions.
       # As of upload-pages-artifact@v1.0.9, permissions must be set explicitly
       # to 0755 (as indicated in warnings produced by v1.0.8)
-      - name: Fix permissions to actions/upload-pages-artifact@v4.0.0
+      - name: Fix permissions to actions/upload-pages-artifact@v5.0.0
         if: always()
         run: sudo chmod -c -R 0755 reports
       - name: Upload artifact
         if: always()
-        uses: actions/upload-pages-artifact@v4.0.0
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: "."
       - name: Deploy to GitHub Pages

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 						<dependency>
 							<groupId>org.apache.ant</groupId>
 							<artifactId>ant-junit</artifactId>
-							<version>1.10.16</version>
+							<version>1.10.17</version>
 						</dependency>
 						<dependency>
 							<groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		
 		<tdrules.version>4.6.2</tdrules.version>
 		
-		<qagrow.version>1.4.310</qagrow.version>
+		<qagrow.version>1.4.311</qagrow.version>
 		
 		<qacover.version>2.1.0</qacover.version>
 	</properties>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-pages-artifact from 4.0.0 to 5.0.0](https://github.com/giis-uniovi/tdrules-st-tdg/pull/189)
- [Bump org.apache.ant:ant-junit from 1.10.16 to 1.10.17](https://github.com/giis-uniovi/tdrules-st-tdg/pull/190)
- [Bump giis:qagrow from 1.4.310 to 1.4.311](https://github.com/giis-uniovi/tdrules-st-tdg/pull/192)
- [Bump actions/cache from 5.0.4 to 5.0.5](https://github.com/giis-uniovi/tdrules-st-tdg/pull/191)