### PR TITLE
Combined dependency updates (2026-04-30)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		
 		<qagrow.version>1.4.311</qagrow.version>
 		
-		<qacover.version>2.1.0</qacover.version>
+		<qacover.version>2.2.0</qacover.version>
 	</properties>
 
 	<modules>

--- a/st-tdg-eval/pom.xml
+++ b/st-tdg-eval/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.44</version>
+			<version>1.18.46</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/st-tdg-eval/pom.xml
+++ b/st-tdg-eval/pom.xml
@@ -144,7 +144,7 @@
 				<!-- Run with: mvn test-compile org.pitest:pitest-maven:mutationCoverage -->
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
-				<version>1.23.0</version>
+				<version>1.23.1</version>
 				<configuration>
 					<targetTests>
 						<param>test4giis.tdrules.tdg.st.eval.petstore.*</param>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.giis-uniovi:qacover-model from 2.1.0 to 2.2.0](https://github.com/giis-uniovi/tdrules-st-tdg/pull/196)
- [Bump org.projectlombok:lombok from 1.18.44 to 1.18.46](https://github.com/giis-uniovi/tdrules-st-tdg/pull/195)
- [Bump org.pitest:pitest-maven from 1.23.0 to 1.23.1](https://github.com/giis-uniovi/tdrules-st-tdg/pull/194)