### PR TITLE
Combined dependency updates (2026-05-19)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
 
       ###### Launch SUTs ######

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.15.0</version>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>17</source>
+						<target>17</target>
 					</configuration>
 				</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>2.0.17</version>
+				<version>2.0.18</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		
 		<tdrules.version>4.6.2</tdrules.version>
 		
-		<qagrow.version>1.4.311</qagrow.version>
+		<qagrow.version>1.4.312</qagrow.version>
 		
 		<qacover.version>2.2.0</qacover.version>
 	</properties>

--- a/st-tdg-eval/pom.xml
+++ b/st-tdg-eval/pom.xml
@@ -17,9 +17,9 @@
 	</organization>
 	
 	<properties>
-		<!-- java 11 required by pitest -->
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<!-- java 11 required by pitest, java 17 required by choco solver -->
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 	</properties>
 	
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump giis:qagrow from 1.4.311 to 1.4.312](https://github.com/giis-uniovi/tdrules-st-tdg/pull/201)
- [Bump org.slf4j:slf4j-api from 2.0.17 to 2.0.18](https://github.com/giis-uniovi/tdrules-st-tdg/pull/200)