### PR TITLE
Combined dependency updates (2026-05-29)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		
 		<tdrules.version>4.6.2</tdrules.version>
 		
-		<qagrow.version>1.4.312</qagrow.version>
+		<qagrow.version>1.4.313</qagrow.version>
 		
 		<qacover.version>2.2.0</qacover.version>
 	</properties>

--- a/st-tdg-eval/pom.xml
+++ b/st-tdg-eval/pom.xml
@@ -144,7 +144,7 @@
 				<!-- Run with: mvn test-compile org.pitest:pitest-maven:mutationCoverage -->
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
-				<version>1.23.1</version>
+				<version>1.25.0</version>
 				<configuration>
 					<targetTests>
 						<param>test4giis.tdrules.tdg.st.eval.petstore.*</param>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.pitest:pitest-maven from 1.23.1 to 1.25.0](https://github.com/giis-uniovi/tdrules-st-tdg/pull/205)
- [Bump giis:qagrow from 1.4.312 to 1.4.313](https://github.com/giis-uniovi/tdrules-st-tdg/pull/204)