### PR TITLE
Combined dependency updates (2026-06-09)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		
 		<tdrules.version>4.6.2</tdrules.version>
 		
-		<qagrow.version>1.4.313</qagrow.version>
+		<qagrow.version>1.4.314</qagrow.version>
 		
 		<qacover.version>2.2.0</qacover.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<surefire.version>3.5.5</surefire.version>
+		<surefire.version>3.5.6</surefire.version>
 		
 		<tdrules.version>4.6.2</tdrules.version>
 		

--- a/st-tdg-eval/pom.xml
+++ b/st-tdg-eval/pom.xml
@@ -144,7 +144,7 @@
 				<!-- Run with: mvn test-compile org.pitest:pitest-maven:mutationCoverage -->
 				<groupId>org.pitest</groupId>
 				<artifactId>pitest-maven</artifactId>
-				<version>1.25.0</version>
+				<version>1.25.3</version>
 				<configuration>
 					<targetTests>
 						<param>test4giis.tdrules.tdg.st.eval.petstore.*</param>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.maven.plugins:maven-surefire-plugin from 3.5.5 to 3.5.6](https://github.com/giis-uniovi/tdrules-st-tdg/pull/207)
- [Bump org.pitest:pitest-maven from 1.25.0 to 1.25.3](https://github.com/giis-uniovi/tdrules-st-tdg/pull/208)
- [Bump giis:qagrow from 1.4.313 to 1.4.314](https://github.com/giis-uniovi/tdrules-st-tdg/pull/209)